### PR TITLE
fix: set `linguist-detectable` to `false` for JS-files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,5 @@
 /.github export-ignore
 CHANGELOG.md export-ignore
 .styleci.yml export-ignore
+
+*.js linguist-detectable=false


### PR DESCRIPTION
Closes #45 